### PR TITLE
Implement simple Flask transcription app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# AM
+# Audio Transcription Service
+
+This is a simple Flask application that performs audio transcription using
+[OpenAI Whisper](https://github.com/openai/whisper) and speaker diarization
+using [pyannote.audio](https://github.com/pyannote/pyannote-audio). The web
+interface allows uploading audio files via drag and drop and displays the
+transcript with speaker labels in a dark themed UI.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set your Hugging Face access token in the environment:
+   ```bash
+   export HUGGINGFACE_TOKEN=your_token_here
+   ```
+
+3. Run the application:
+   ```bash
+   python app.py
+   ```
+
+4. Open `http://localhost:5000` in your browser and upload an audio file.
+
+The resulting transcript can be downloaded as a text file.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+from flask import Flask, request, jsonify, render_template
+import whisper
+from pyannote.audio import Pipeline
+
+app = Flask(__name__)
+
+# Load models once at startup for efficiency
+whisper_model = whisper.load_model("base")
+
+def load_diarization_pipeline():
+    token = os.environ.get("HUGGINGFACE_TOKEN")
+    if not token:
+        raise RuntimeError("HUGGINGFACE_TOKEN environment variable not set")
+    return Pipeline.from_pretrained(
+        "pyannote/speaker-diarization@2.1",
+        use_auth_token=token,
+    )
+
+diarization_pipeline = None
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    global diarization_pipeline
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file uploaded'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'Empty filename'}), 400
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
+        file.save(tmp.name)
+        audio_path = tmp.name
+
+    # Transcription
+    result = whisper_model.transcribe(audio_path, word_timestamps=True)
+    segments = result.get('segments', [])
+
+    # Diarization
+    if diarization_pipeline is None:
+        diarization_pipeline = load_diarization_pipeline()
+    diarization = diarization_pipeline(audio_path)
+
+    # Assign speaker labels to transcription segments
+    transcript_lines = []
+    for segment in segments:
+        start = segment['start']
+        speaker = 'Speaker ?'
+        for turn, _, label in diarization.itertracks(yield_label=True):
+            if turn.start <= start <= turn.end:
+                speaker = label
+                break
+        line = f"{speaker}: {segment['text'].strip()}"
+        transcript_lines.append(line)
+
+    os.unlink(audio_path)
+    return jsonify({'text': '\n'.join(transcript_lines)})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+openai-whisper
+pyannote.audio

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Audio Transcription</title>
+<style>
+body {
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
+#drop-area {
+  border: 2px dashed #555;
+  border-radius: 5px;
+  width: 80%;
+  padding: 40px;
+  text-align: center;
+  margin-top: 40px;
+}
+.progress {
+  width: 80%;
+  background-color: #333;
+  border-radius: 5px;
+  overflow: hidden;
+  margin-top: 20px;
+}
+.progress-bar {
+  height: 20px;
+  background-color: #66bb6a;
+  width: 0%;
+}
+#result {
+  white-space: pre-wrap;
+  margin-top: 20px;
+  width: 80%;
+}
+button {
+  background-color: #444;
+  color: #eee;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+</style>
+</head>
+<body>
+  <h1>Audio Transcription with Diarization</h1>
+  <div id="drop-area">
+    <p>Drag & drop an audio file here or click to select.</p>
+    <input type="file" id="fileElem" accept="audio/*" style="display:none" />
+    <button id="fileSelect">Select File</button>
+  </div>
+  <div class="progress" id="progress" style="display:none">
+    <div class="progress-bar" id="progress-bar"></div>
+  </div>
+  <pre id="result"></pre>
+  <button id="download" style="display:none">Download Text</button>
+<script>
+const dropArea = document.getElementById('drop-area');
+const fileElem = document.getElementById('fileElem');
+const fileSelect = document.getElementById('fileSelect');
+const progressBar = document.getElementById('progress-bar');
+const progress = document.getElementById('progress');
+const result = document.getElementById('result');
+const download = document.getElementById('download');
+
+fileSelect.addEventListener('click', () => fileElem.click());
+fileElem.addEventListener('change', handleFiles);
+dropArea.addEventListener('dragover', (e) => { e.preventDefault(); dropArea.classList.add('highlight');});
+dropArea.addEventListener('dragleave', () => dropArea.classList.remove('highlight'));
+dropArea.addEventListener('drop', (e) => { e.preventDefault(); handleFiles(e);});
+
+function handleFiles(e) {
+  const files = e.target.files || e.dataTransfer.files;
+  if (!files.length) return;
+  uploadFile(files[0]);
+}
+
+function uploadFile(file) {
+  const url = '/upload';
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', url, true);
+  xhr.upload.addEventListener('progress', e => {
+    progress.style.display = 'block';
+    const percent = (e.loaded / e.total) * 100;
+    progressBar.style.width = percent + '%';
+  });
+  xhr.onload = function () {
+    if (xhr.status === 200) {
+      progressBar.style.width = '100%';
+      const data = JSON.parse(xhr.responseText);
+      result.textContent = data.text;
+      download.style.display = 'inline-block';
+      const blob = new Blob([data.text], {type: 'text/plain'});
+      download.href = URL.createObjectURL(blob);
+      download.download = 'transcript.txt';
+    } else {
+      result.textContent = 'Error: ' + xhr.statusText;
+    }
+  };
+  xhr.send(formData);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based web app using Whisper and pyannote for speaker diarization
- dark theme drag&drop page with a progress bar
- document setup and usage in README
- include requirements file

## Testing
- `python -m py_compile app.py`
- ❌ `pip install openai-whisper pyannote.audio` *(failed: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68605900f9c0833393a7c9a792307ffd